### PR TITLE
open up raw constructors

### DIFF
--- a/src/main/java/org/ejbca/cvc/AccessRightsRawValue.java
+++ b/src/main/java/org/ejbca/cvc/AccessRightsRawValue.java
@@ -26,7 +26,7 @@ public class AccessRightsRawValue implements AccessRights {
 
    private final byte[] bytes;
 
-   AccessRightsRawValue(byte[] bytes) {
+   public AccessRightsRawValue(byte[] bytes) {
       this.bytes = bytes;
    }
 

--- a/src/main/java/org/ejbca/cvc/AuthorizationRoleRawValue.java
+++ b/src/main/java/org/ejbca/cvc/AuthorizationRoleRawValue.java
@@ -24,7 +24,7 @@ public class AuthorizationRoleRawValue implements AuthorizationRole {
    
    private final byte value;
    
-   AuthorizationRoleRawValue(byte value) {
+   public AuthorizationRoleRawValue(byte value) {
       this.value = value;
    }
    


### PR DESCRIPTION
To be actually able to construct and not only parse CV Certificates with a custom CHAT, raw values need to created from the caller.

This is closely related to the modification introduced in #1 